### PR TITLE
Add a BFT consensus prop test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,8 @@ repository = "https://github.com/maidsafe/brb_membership"
 edition = "2021"
 
 [dependencies]
-crdts = "5.0.0"
 rand = "0.7.3"
-serde = "1.0.106"
+serde = {version = "1", features = ["derive"]}
 bincode = "1.2.1"
 hex = "0.4.2"
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,20 @@ log = "0.4.13"
 
 [features]
 default = [ "blsttc" ]
+bad_crypto = [] # stubbed out crypto for fast tests
+
+[profile.test]
+opt-level = 3
+debug = true
+overflow-checks = true
+
+[profile.bench]
+debug = true
+
+[profile.release]
+debug = true
 
 [dev-dependencies]
 eyre = "0.6.5"
+quickcheck = "1"
+quickcheck_macros = "1"

--- a/quickcheck_forever.sh
+++ b/quickcheck_forever.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+export QUICKCHECK_TESTS=10000000
+
+while true
+do
+    cargo test --no-default-features --features bad_crypto prop_
+    if [[ x$? != x0 ]] ; then
+        exit $?
+    fi
+done

--- a/src/bad_crypto.rs
+++ b/src/bad_crypto.rs
@@ -1,0 +1,77 @@
+/**
+ * This module provides a *broken* "asymmetric" crypto module that is used to
+ * mock out real crypto implementation for tests.
+ *
+ * Don't use this in production.
+ */
+use rand::{CryptoRng, Rng};
+use serde::{Deserialize, Serialize};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Failed Verification")]
+    FailedVerification,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct PublicKey(u64);
+
+impl PublicKey {
+    pub fn random(rng: impl Rng + CryptoRng) -> Self {
+        SecretKey::random(rng).public_key()
+    }
+
+    pub fn verify(&self, msg: &[u8], signature: &Signature) -> Result<(), Error> {
+        let mut hasher = DefaultHasher::new();
+
+        self.0.hash(&mut hasher);
+        msg.hash(&mut hasher);
+
+        if hasher.finish() == signature.0 {
+            Ok(())
+        } else {
+            Err(Error::FailedVerification)
+        }
+    }
+}
+
+impl core::fmt::Debug for PublicKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Display::fmt(self, f)
+    }
+}
+
+impl core::fmt::Display for PublicKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let bytes = self.0.to_le_bytes();
+        write!(f, "i:{}", hex::encode(&bytes[..3]))
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SecretKey(u64);
+
+impl SecretKey {
+    pub fn random(mut rng: impl Rng + CryptoRng) -> Self {
+        Self(rng.gen())
+    }
+
+    pub fn public_key(&self) -> PublicKey {
+        PublicKey(self.0)
+    }
+
+    pub fn sign(&self, msg: &[u8]) -> Signature {
+        let mut hasher = DefaultHasher::new();
+
+        self.0.hash(&mut hasher);
+        msg.hash(&mut hasher);
+
+        Signature(hasher.finish())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct Signature(u64);

--- a/src/brb_membership.rs
+++ b/src/brb_membership.rs
@@ -392,7 +392,7 @@ impl State {
         Ok(vec![])
     }
 
-    fn sign_vote(&self, vote: Vote) -> Result<SignedVote, Error> {
+    pub fn sign_vote(&self, vote: Vote) -> Result<SignedVote, Error> {
         Ok(SignedVote {
             voter: self.public_key(),
             sig: self.secret_key.sign(&vote.to_bytes()?),

--- a/src/brb_membership.rs
+++ b/src/brb_membership.rs
@@ -483,6 +483,7 @@ impl State {
 
     pub fn validate_signed_vote(&self, signed_vote: &SignedVote) -> Result<(), Error> {
         signed_vote.validate_signature()?;
+        self.validate_vote(&signed_vote.vote)?;
 
         let members = self.members(self.gen)?;
         if !members.contains(&signed_vote.voter) {
@@ -497,12 +498,7 @@ impl State {
             Err(Error::ExistingVoteIncompatibleWithNewVote {
                 existing_vote: self.votes[&signed_vote.voter].clone(),
             })
-        } else if self.pending_gen == self.gen {
-            // We are starting a vote for the next generation
-            self.validate_vote(&signed_vote.vote)
         } else {
-            // This is a vote for this generation
-
             // Ensure that nobody is trying to change their reconfig's.
             let reconfigs: BTreeSet<(PublicKey, Reconfig)> = self
                 .votes
@@ -515,7 +511,7 @@ impl State {
             if voters.len() != reconfigs.len() {
                 Err(Error::VoterChangedMind { reconfigs })
             } else {
-                self.validate_vote(&signed_vote.vote)
+                Ok(())
             }
         }
     }

--- a/src/brb_membership.rs
+++ b/src/brb_membership.rs
@@ -30,8 +30,8 @@ pub enum Reconfig {
 impl std::fmt::Debug for Reconfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Reconfig::Join(a) => write!(f, "J{:?}", a),
-            Reconfig::Leave(a) => write!(f, "L{:?}", a),
+            Reconfig::Join(a) => write!(f, "J{}", a),
+            Reconfig::Leave(a) => write!(f, "L{}", a),
         }
     }
 }
@@ -118,7 +118,7 @@ pub struct SignedVote {
 
 impl Debug for SignedVote {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}@{:?}", self.vote, self.voter)
+        write!(f, "{:?}@{}", self.vote, self.voter)
     }
 }
 

--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -4,7 +4,7 @@ use signature::{Signer, Verifier};
 
 pub type Error = signature::Error;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PublicKey(ed25519::PublicKey);
 
 impl PublicKey {
@@ -14,6 +14,12 @@ impl PublicKey {
 
     pub fn verify(&self, msg: &[u8], signature: &Signature) -> Result<(), Error> {
         self.0.verify(msg, &signature.0)
+    }
+}
+
+impl core::fmt::Debug for PublicKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Display::fmt(self, f)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -69,4 +69,8 @@ pub enum Error {
     #[cfg(feature = "blsttc")]
     #[error("Blsttc Error {0}")]
     Blsttc(#[from] crate::blsttc::Error),
+
+    #[cfg(feature = "bad_crypto")]
+    #[error("Failed Signature Verification")]
+    BadCrypto(#[from] crate::bad_crypto::Error),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,16 @@
 // #![deny(missing_docs)]
 #[cfg(any(
     all(feature = "ed25519", feature = "blsttc"),
-    not(any(feature = "ed25519", feature = "blsttc"))
+    all(feature = "bad_crypto", feature = "ed25519"),
+    all(feature = "bad_crypto", feature = "blsttc"),
+    not(any(feature = "ed25519", feature = "blsttc", feature = "bad_crypto"))
 ))]
-compile_error!("Must enable either `ed25519` or `blsttc` feature flags");
+compile_error!("Must enable either `ed25519`, `blsttc` or `bad_crypto` feature flags");
 
 pub mod brb_membership;
 
+#[cfg(feature = "bad_crypto")]
+pub mod bad_crypto;
 #[cfg(feature = "blsttc")]
 pub mod blsttc;
 #[cfg(feature = "ed25519")]
@@ -14,6 +18,8 @@ pub mod ed25519;
 
 pub use crate::brb_membership::{Ballot, Generation, Reconfig, SignedVote, State, Vote, VoteMsg};
 
+#[cfg(feature = "bad_crypto")]
+pub use crate::bad_crypto::{PublicKey, SecretKey, Signature};
 #[cfg(feature = "blsttc")]
 pub use crate::blsttc::{PublicKey, SecretKey, Signature};
 #[cfg(feature = "ed25519")]


### PR DESCRIPTION
This adds prop testing for

1. termination -> all honest nodes eventually terminate with all honest nodes agreeing to *something*
2. agreement -> once all honest nodes terminate, they agree on what they decided on.

I did find one bug in the validations where we were letting in votes from a future generation.

I also went through and commented out random sections of the algorithm and in all cases we either had a failing test case, or we the test-cases never terminated so I'm fairly confident that we are now properly exercising all aspects of the algorithm.